### PR TITLE
Add set generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
         </developer>
     </developers>
     <contributors>
+      <contributor>
+        <name>Hans Pikkemaat</name>
+        <email>thehpi@hotmail.com</email>
+        <roles>
+          <role>contributor</role>
+        </roles>
+        <timezone>Europe/Amsterdam</timezone>
+      </contributor>
     </contributors>
     <dependencies>
         <dependency>

--- a/src/main/java/com/google/code/beanmatchers/BeanMatchers.java
+++ b/src/main/java/com/google/code/beanmatchers/BeanMatchers.java
@@ -2,6 +2,7 @@ package com.google.code.beanmatchers;
 
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import org.hamcrest.Matcher;
 
@@ -24,6 +25,7 @@ public final class BeanMatchers {
     repo.registerValueGenerator(new CharacterGenerator(random), Character.class, Character.TYPE);
     repo.registerValueGenerator(new ShortGenerator(random), Short.class, Short.TYPE);
     repo.registerValueGenerator(new ListGenerator(random), List.class);
+    repo.registerValueGenerator(new SetGenerator(random), Set.class);
     VALUE_GENERATOR_REPOSITORY = repo;
     final ArrayTypeBasedValueGenerator arrayValueGenerator = new ArrayTypeBasedValueGenerator();
     TYPE_BASED_VALUE_GENERATOR = new DefaultTypeBasedValueGenerator(

--- a/src/main/java/com/google/code/beanmatchers/SetGenerator.java
+++ b/src/main/java/com/google/code/beanmatchers/SetGenerator.java
@@ -1,0 +1,23 @@
+package com.google.code.beanmatchers;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+class SetGenerator implements ValueGenerator<Set> {
+
+  private final Random random;
+
+  public SetGenerator(Random random) {
+    this.random = random;
+  }
+
+  public Set generate() {
+    HashSet<Integer> hash = new HashSet<>();
+    for (int count = 1; count <= 3; count++) {
+      hash.add(1 + random.nextInt());
+    }
+
+    return hash;
+  }
+}

--- a/src/main/java/com/google/code/beanmatchers/SetGenerator.java
+++ b/src/main/java/com/google/code/beanmatchers/SetGenerator.java
@@ -1,6 +1,7 @@
 package com.google.code.beanmatchers;
 
-import java.util.HashSet;
+import static java.util.Collections.singleton;
+
 import java.util.Random;
 import java.util.Set;
 
@@ -13,11 +14,6 @@ class SetGenerator implements ValueGenerator<Set> {
   }
 
   public Set generate() {
-    HashSet<Integer> hash = new HashSet<>();
-    for (int count = 1; count <= 3; count++) {
-      hash.add(1 + random.nextInt());
-    }
-
-    return hash;
+    return singleton(random.nextInt());
   }
 }

--- a/src/test/java/com/google/code/beanmatchers/SetGeneratorTest.java
+++ b/src/test/java/com/google/code/beanmatchers/SetGeneratorTest.java
@@ -1,0 +1,42 @@
+package com.google.code.beanmatchers;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SetGeneratorTest {
+
+  private SetGenerator unitUnderTest;
+
+  private final Random random = new Random();
+
+  @BeforeMethod
+  public void setUp() {
+    unitUnderTest = new SetGenerator(random);
+  }
+
+  @Test
+  public void shouldProvideList() {
+    // when
+    Set result = unitUnderTest.generate();
+
+    // then
+    assertThat(result, is(notNullValue()));
+  }
+
+  @Test
+  public void shouldProvideDifferingValueOnSubsequentCall() {
+    // when
+    Set result1 = unitUnderTest.generate();
+    Set result2 = unitUnderTest.generate();
+
+    // then
+    assertThat(result1, is(not(equalTo(result2))));
+  }
+}

--- a/src/test/java/com/google/code/beanmatchers/data/TestBeanWithManyProperties.java
+++ b/src/test/java/com/google/code/beanmatchers/data/TestBeanWithManyProperties.java
@@ -9,6 +9,7 @@ import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToStrin
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 public class TestBeanWithManyProperties {
 
@@ -40,6 +41,7 @@ public class TestBeanWithManyProperties {
   private List<String> listOfString;
   private List<Long> listOfLong;
   private List<Boolean> unmodifiableList;
+  private Set<String> unmodifiableSet;
 
   public Object getObject() {
     return object;
@@ -263,6 +265,14 @@ public class TestBeanWithManyProperties {
 
   public void setUnmodifiableList(List<Boolean> unmodifiableList) {
     this.unmodifiableList = unmodifiableList == null ? null : Collections.unmodifiableList(unmodifiableList);
+  }
+
+  public Set<String> getUnmodifiableSet() {
+    return unmodifiableSet == null ? null : Collections.unmodifiableSet(unmodifiableSet);
+  }
+
+  public void setUnmodifiableSet(Set<String> unmodifiableSet) {
+    this.unmodifiableSet = unmodifiableSet == null ? null : Collections.unmodifiableSet(unmodifiableSet);
   }
 
   @Override


### PR DESCRIPTION
Hi,

I added a SetGenerator which allows to wrap a Set in another set in a getter without causing a problem.

A getter will then look like this:

    public void setMyset(Set<String> myset) {
      if (myset == null) {
        this.myset = null;
        return;
      }
      this.myset = new HashSet<>(myset);
    }

Would be nice if you could include this.

Best regards, Hans